### PR TITLE
fix 'calendar_return' function in table.py

### DIFF
--- a/performanceanalytics/table/table.py
+++ b/performanceanalytics/table/table.py
@@ -65,7 +65,7 @@ def calendar_returns(data_series, manager_col=0, index_cols=None, as_perc=False)
             idx = '-'.join([str(y), str(m)])
             # see if the index is in there
             if idx in _s.index:
-                df.iloc[mc][y] = _s[idx]
+                df.iloc[mc][y] = np.prod(1+_s[idx].dropna()) - 1
 
     # we now have the data frame, now we can append the annual returns as the last row
     annual_returns = []


### PR DESCRIPTION
corresponding Function in R is implemented

https://github.com/R-Finance/PerformanceAnalytics/blob/master/R/table.CalendarReturns.R

```r
for (i in 1:length(yearcol[,1])) {
			if(geometric)
				yearcol[i,columnnames[column]] = prod(1 + na.omit(as.numeric(target.df[i,])))-1
			else
				yearcol[i,columnnames[column]] = sum(as.numeric(target.df[i,]), na.rm=TRUE)
			if(yearcol[i,columnnames[column]]== 0) 
                yearcol[i,columnnames[column]] = NA
        }

```
current function makes ValueError: No axis named 1 for object type <class 'pandas.core.series.Series'>